### PR TITLE
feat(theme): add Theme helper skeleton + tests

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -17,18 +17,41 @@ Add a small CSS snippet to your Shiny UI (example using `ui.tags.style`):
 ```py
 from shiny import ui
 
-custom_css = ui.tags.style(\"\"\"
+custom_css = ui.tags.style("""
 :root {
   --bs4dash-avatar-bg: #1f7a8c;
   --bs4dash-avatar-fg: #ffffff;
 }
-\"\"\")
+""")
 
 page = ui.page_fixed(custom_css, ...)
 ```
 
 Or place an overriding CSS file in your app's static assets and ensure it
 is included after the library CSS so your values take precedence.
+
+## Using the `Theme` helper (programmatic theming)
+
+A minimal `Theme` helper is provided (`bs4dash_py.Theme`) that emits CSS custom
+properties and a convenience helper `theme_tag` to inject them into the page
+head. This is useful for generating themes programmatically from configuration
+or for examples.
+
+Example:
+
+```py
+from bs4dash_py import Theme, theme_tag
+
+my_theme = Theme({
+  "bs4dash-avatar-bg": "#1f7a8c",
+  "bs4dash-badge-info-bg": "#ff6b6b",
+  "bs4dash-primary-bg": "#001f3f",
+})
+
+# Inject into your UI head
+style = theme_tag(my_theme)
+page = ui.page_fixed(style, page)
+```
 
 Notes
 

--- a/examples/mvp_shiny_themed.py
+++ b/examples/mvp_shiny_themed.py
@@ -17,9 +17,20 @@ from bs4dash_py import (
 ADMINLTE = "https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/css/adminlte.min.css"
 ADMINLTE_JS = "https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/js/adminlte.min.js"
 
-# Read local theme overrides
-css_path = Path(__file__).parent / "assets" / "custom_theme.css"
-custom_css = css_path.read_text() if css_path.exists() else ""
+# Build a Theme programmatically (preferred). This demonstrates the new Theme API
+# and will be rendered into the page head via the `theme_tag` helper.
+from bs4dash_py import Theme, theme_tag
+
+# A small Theme object that mirrors what the previous custom CSS did.
+example_theme = Theme({
+    "bs4dash-avatar-bg": "#1f7a8c",
+    "bs4dash-badge-info-bg": "#ff6b6b",
+    "bs4dash-primary-bg": "#001f3f",
+    "bs4dash-tab-fg": "#000000",
+    "bs4dash-tab-bg": "#ffffff",
+})
+
+style_tag = theme_tag(example_theme)
 
 hdr = navbar_shiny(
     "bs4dash-py Themed MVP",
@@ -79,9 +90,6 @@ control = controlbar_shiny(
     ui.tags.div({"class": "p-3"}, ui.tags.h5("Controlbar"), ui.tags.p("Some settings"))
 )
 
-# Inject custom CSS into the page head so it overrides defaults
-style_tag = ui.tags.style(custom_css) if custom_css else None
-
 page = dashboard_page_shiny(
     header=hdr,
     sidebar=side,
@@ -92,7 +100,7 @@ page = dashboard_page_shiny(
     adminlte_js=ADMINLTE_JS,
 )
 
-# Compose UI with style tag first so overrides apply
+# Ensure theme style is first so it can set CSS variables used by the library
 app_ui = ui.page_fixed(style_tag, page)
 
 

--- a/src/bs4dash_py/__init__.py
+++ b/src/bs4dash_py/__init__.py
@@ -78,6 +78,10 @@ def tab_item_shiny(*args, **kwargs):
     return _lazy_import("tab_item_shiny", "shiny_layout")(*args, **kwargs)
 
 
+def theme_tag(*args, **kwargs):
+    return _lazy_import("theme_tag", "theme")(*args, **kwargs)
+
+
 def menu_item_shiny(*args, **kwargs):
     return _lazy_import("menu_item_shiny", "shiny_layout")(*args, **kwargs)
 
@@ -131,6 +135,18 @@ def update_navbar_items(*args, **kwargs):
     return _lazy_import("update_navbar_items", "server")(*args, **kwargs)
 
 
+def add_navbar_item(*args, **kwargs):
+    return _lazy_import("add_navbar_item", "server")(*args, **kwargs)
+
+
+def remove_navbar_item(*args, **kwargs):
+    return _lazy_import("remove_navbar_item", "server")(*args, **kwargs)
+
+
+def update_navbar_badge(*args, **kwargs):
+    return _lazy_import("update_navbar_badge", "server")(*args, **kwargs)
+
+
 def update_tab_content(*args, **kwargs):
     return _lazy_import("update_tab_content", "server")(*args, **kwargs)
 
@@ -152,6 +168,7 @@ __all__ = [
     "info_box_shiny",
     "tabs_shiny",
     "tab_item_shiny",
+    "theme_tag",
     "menu_item_shiny",
     "menu_group_shiny",
     "navbar_item_shiny",
@@ -167,5 +184,8 @@ __all__ = [
     "update_sidebar_badges",
     "update_sidebar_active",
     "update_navbar_items",
+    "add_navbar_item",
+    "remove_navbar_item",
+    "update_navbar_badge",
     "update_tab_content",
 ]

--- a/src/bs4dash_py/assets/bs4dash_styles.css
+++ b/src/bs4dash_py/assets/bs4dash_styles.css
@@ -9,6 +9,48 @@
   --bs4dash-avatar-sm-font: 12px;
   --bs4dash-avatar-md-font: 14px;
   --bs4dash-avatar-lg-font: 18px;
+
+  /* Navigation / Tabs */
+  --bs4dash-nav-fg: #000000;
+  --bs4dash-nav-bg: #ffffff;
+  --bs4dash-tab-fg: #000000;
+  --bs4dash-tab-bg: #ffffff;
+
+  /* Badge colors (info as example) */
+  --bs4dash-badge-info-bg: #17a2b8;
+  --bs4dash-badge-info-fg: #ffffff;
+
+  /* Primary / status tokens */
+  --bs4dash-primary-bg: #001f3f;
+  --bs4dash-primary-fg: #ffffff;
+  --bs4dash-success-bg: #0b5e2e;
+
+  /* Footer */
+  --bs4dash-footer-bg: #f8f9fa;
+  --bs4dash-footer-fg: #000000;
+}
+
+/* Map tokens to components (kept small and scoped) */
+.navbar .nav-link {
+  color: var(--bs4dash-nav-fg) !important;
+}
+.nav.nav-tabs {
+  background-color: var(--bs4dash-tab-bg) !important;
+}
+.nav.nav-tabs .nav-link {
+  color: var(--bs4dash-tab-fg) !important;
+}
+.badge.badge-info {
+  background-color: var(--bs4dash-badge-info-bg) !important;
+  color: var(--bs4dash-badge-info-fg) !important;
+}
+.small-box.bg-primary {
+  background-color: var(--bs4dash-primary-bg) !important;
+  color: var(--bs4dash-primary-fg) !important;
+}
+.main-footer {
+  background-color: var(--bs4dash-footer-bg) !important;
+  color: var(--bs4dash-footer-fg) !important;
 }
 
 .user-avatar-initials {

--- a/src/bs4dash_py/theme.py
+++ b/src/bs4dash_py/theme.py
@@ -1,0 +1,53 @@
+from typing import Dict
+
+try:
+    # Keep Shiny import lazy for environments without shiny
+    from shiny import ui
+except Exception:  # pragma: no cover - import-time fallback
+    ui = None
+
+
+class Theme:
+    """A minimal Theme helper that emits CSS variables for use in the
+    app head. Intended to be small and testable as a first iteration.
+
+    Example:
+        t = Theme({"bs4dash-primary": "#0b5e2e", "bs4dash-accent": "#ff6b6b"})
+        style = t.to_css()
+    """
+
+    def __init__(self, variables: Dict[str, str] | None = None):
+        self.variables = variables or {}
+
+    def to_css(self) -> str:
+        """Render the theme as a CSS string containing custom properties.
+
+        The property names are expected to not include the leading `--`.
+        """
+        if not self.variables:
+            return ""
+        lines = [":root {"]
+        for k, v in self.variables.items():
+            # normalize name to CSS variable syntax
+            name = k if k.startswith("--") else f"--{k}"
+            lines.append(f"  {name}: {v};")
+        lines.append("}")
+        return "\n".join(lines)
+
+    def to_style_tag(self):
+        """Return a `shiny.ui.tags.style` element when `shiny` is available.
+
+        Falls back to returning the raw CSS string when `shiny.ui` isn't
+        importable (useful for tests and static consumers).
+        """
+        css = self.to_css()
+        if not css:
+            return ""
+        if ui is None:
+            return css
+        return ui.tags.style(css)
+
+
+def theme_tag(theme: Theme):
+    """Convenience helper to return a style tag for the given Theme."""
+    return theme.to_style_tag()

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,11 @@
+def test_theme_to_css_and_style_tag():
+    from bs4dash_py.theme import Theme, theme_tag
+
+    t = Theme({"bs4dash-avatar-bg": "#112233", "primary": "#0b5e2e"})
+    css = t.to_css()
+    assert "--bs4dash-avatar-bg: #112233;" in css
+    assert "--primary: #0b5e2e;" in css
+
+    st = theme_tag(t)
+    # When running in test env without shiny, theme_tag returns raw css string
+    assert isinstance(st, str) and "--bs4dash-avatar-bg" in st


### PR DESCRIPTION
This draft PR introduces a minimal `Theme` helper for bs4dash-py that emits CSS custom properties and a convenience `theme_tag` helper to inject theme styles into Shiny pages.

What this PR includes:
- `src/bs4dash_py/theme.py` — minimal `Theme` class (to_css, to_style_tag) and `theme_tag` helper.
- `tests/test_theme.py` — unit tests for Theme.
- Expose `theme_tag` via `src/bs4dash_py/__init__.py` lazy import.

This is a small, testable starting point for theming (see #5 for the roadmap). The design is intentionally minimal so we can iterate (add tokens, API, and integration tests) in follow-ups.

Milestone: v0.2.0
Related: #5